### PR TITLE
fix: Re-export type error when importing

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -6,4 +6,4 @@ export { Packet } from "./src/packet.ts";
 export { Sender } from "./src/sender.ts";
 export { Server } from "./src/server.ts";
 export { Transmitter } from "./src/transmitter.ts";
-export { ITransmitterOptions } from "./src/interfaces.ts";
+export type { ITransmitterOptions } from "./src/interfaces.ts";

--- a/tests/unit/channel_test.ts
+++ b/tests/unit/channel_test.ts
@@ -1,5 +1,5 @@
 import { Rhum } from "../deps.ts";
-import { Channel } from "../../src/channel.ts";
+import { Channel } from "../../mod.ts";
 
 Rhum.testPlan("unit/channel_test.ts", () => {
   Rhum.testSuite("constructor()", () => {

--- a/tests/unit/client_test.ts
+++ b/tests/unit/client_test.ts
@@ -1,5 +1,5 @@
 import { Rhum } from "../deps.ts";
-import { Client } from "../../src/client.ts";
+import { Client } from "../../mod.ts";
 import { WebSocket } from "../../deps.ts";
 
 const ClientSocket = () => {

--- a/tests/unit/event_emitter_test.ts
+++ b/tests/unit/event_emitter_test.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "../../src/event_emitter.ts";
+import { EventEmitter } from "../../mod.ts";
 import { Rhum, WebSocket } from "../deps.ts";
 
 const ClientSocket = () => {

--- a/tests/unit/packet_test.ts
+++ b/tests/unit/packet_test.ts
@@ -1,6 +1,5 @@
 import { Rhum } from "../deps.ts";
-import { Packet } from "../../src/packet.ts";
-import { Client } from "../../src/client.ts";
+import { Packet, Client } from "../../mod.ts";
 import { WebSocket } from "../../deps.ts";
 
 const ClientSocket = () => {

--- a/tests/unit/packet_test.ts
+++ b/tests/unit/packet_test.ts
@@ -1,5 +1,5 @@
 import { Rhum } from "../deps.ts";
-import { Packet, Client } from "../../mod.ts";
+import { Client, Packet } from "../../mod.ts";
 import { WebSocket } from "../../deps.ts";
 
 const ClientSocket = () => {

--- a/tests/unit/reserved_event_names_test.ts
+++ b/tests/unit/reserved_event_names_test.ts
@@ -1,4 +1,4 @@
-import { RESERVED_EVENT_NAMES } from "../../src/reserved_event_names.ts";
+import { RESERVED_EVENT_NAMES } from "../../mod.ts";
 import { Rhum } from "../deps.ts";
 
 Rhum.testPlan("unit/reserved_event_names_test.ts", () => {

--- a/tests/unit/sender_test.ts
+++ b/tests/unit/sender_test.ts
@@ -1,9 +1,4 @@
 import { Rhum } from "../deps.ts";
-import { Sender } from "../../src/sender.ts";
-import { Packet } from "../../src/packet.ts";
-import { Client } from "../../src/client.ts";
-import { WebSocket } from "../../deps.ts";
-import { Channel } from "../../src/channel.ts";
 
 const ClientSocket = () => {
   return {

--- a/tests/unit/server_test.ts
+++ b/tests/unit/server_test.ts
@@ -1,4 +1,4 @@
-import { Server } from "../../src/server.ts";
+import { Server } from "../../mod.ts";
 import { Rhum } from "../deps.ts";
 
 Rhum.testPlan("unit/server_test.ts", () => {

--- a/tests/unit/tests.ts
+++ b/tests/unit/tests.ts
@@ -1,4 +1,4 @@
-import * as something from "../../mod.ts"
+import * as something from "../../mod.ts";
 
 import "./event_emitter_test.ts";
 import "./server_test.ts";

--- a/tests/unit/tests.ts
+++ b/tests/unit/tests.ts
@@ -1,3 +1,5 @@
+import * as something from "../../mod.ts"
+
 import "./event_emitter_test.ts";
 import "./server_test.ts";
 import "./reserved_event_names_test.ts";

--- a/tests/unit/tests.ts
+++ b/tests/unit/tests.ts
@@ -1,5 +1,3 @@
-import * as something from "../../mod.ts";
-
 import "./event_emitter_test.ts";
 import "./server_test.ts";
 import "./reserved_event_names_test.ts";

--- a/tests/unit/transmitter_test.ts
+++ b/tests/unit/transmitter_test.ts
@@ -1,5 +1,11 @@
 import { Rhum } from "../deps.ts";
-import { Transmitter, Server, Packet, Client, EventEmitter } from "../../mod.ts";
+import {
+  Client,
+  EventEmitter,
+  Packet,
+  Server,
+  Transmitter,
+} from "../../mod.ts";
 import { WebSocket } from "../../deps.ts";
 
 const ClientSocket = () => {

--- a/tests/unit/transmitter_test.ts
+++ b/tests/unit/transmitter_test.ts
@@ -1,10 +1,6 @@
 import { Rhum } from "../deps.ts";
-import { Transmitter } from "../../src/transmitter.ts";
-import { Server } from "../../src/server.ts";
-import { Packet } from "../../src/packet.ts";
-import { Client } from "../../src/client.ts";
+import { Transmitter, Server, Packet, Client, EventEmitter } from "../../mod.ts";
 import { WebSocket } from "../../deps.ts";
-import { EventEmitter } from "../../src/event_emitter.ts";
 
 const ClientSocket = () => {
   return {


### PR DESCRIPTION
Importing anything from `mod.ts` fails, this fixes that issue, and we are now importing from mod.ts for the tests so we can catch this issue
