### PR TITLE
fix: Send `disconnect` event when a client disconnects

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Integration
         run: |
-          #deno test --allow-all tests/integration/app_3000/tests.ts
+          deno test --allow-all tests/integration/app_3000/tests.ts
           #deno test --allow-all tests/integration/app_3001/tests.ts # throws rust errors
 
   linter:

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,6 +169,12 @@ export class Server extends EventEmitter {
 
                 // Handle disconnects
               } else if (isWebSocketCloseEvent(message)) {
+                await this.transmitter.handlePacket(
+                  new Packet(
+                    client,
+                    "disconnect",
+                  ),
+                );
                 super.removeClient(client.id);
               }
             }


### PR DESCRIPTION
Fixes #105 

## Summary

* Wocket now sends a messagr to the `disconnect` handler
* Added tests for this
* Added tests for the connect reserved event too
* Restructured the app_3000 tests so it's easier to work with
* Re enabled these tests in the ci (not sure why they were disabled)
