### PR TITLE
feat: Support paths

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -195,9 +195,7 @@ export class Server {
     return async function (r: Request): Promise<Response> {
       const url = new URL(r.url);
       const { pathname } = url;
-      console.log(r.url);
       if (options.path && options.path !== pathname) {
-        console.log("whaa");
         return new Response(
           "The client has not specified the correct path that the server is listening on.",
           {
@@ -205,9 +203,7 @@ export class Server {
           },
         );
       }
-      console.log(1);
       const { socket, response } = Deno.upgradeWebSocket(r);
-      console.log(2);
 
       // Create the client
       const client = new Client(clients.size, socket);
@@ -249,7 +245,6 @@ export class Server {
 
       // When the socket calls `.close()`, then do the following
       socket.onclose = (ev: CloseEvent) => {
-        console.log("close handler in server");
         // Remove the client
         clients.delete(client.id);
         // Call the disconnect handler if defined

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,8 @@ export interface IOptions {
   keyFile?: string;
   /** Path to the cert file if using wss */
   certFile?: string;
+  /** The path of which this server will handle connections for. Defaults to "/" */
+  path?: string;
 }
 
 type TRequestHandler = (r: Request) => Promise<Response>;
@@ -187,10 +189,25 @@ export class Server {
   #getHandler(): TRequestHandler {
     const clients = this.clients;
     const channels = this.channels;
+    const options = this.#options;
 
     // deno-lint-ignore require-await
     return async function (r: Request): Promise<Response> {
+      const url = new URL(r.url);
+      const { pathname } = url;
+      console.log(r.url);
+      if (options.path && options.path !== pathname) {
+        console.log("whaa");
+        return new Response(
+          "The client has not specified the correct path that the server is listening on.",
+          {
+            status: 406,
+          },
+        );
+      }
+      console.log(1);
       const { socket, response } = Deno.upgradeWebSocket(r);
+      console.log(2);
 
       // Create the client
       const client = new Client(clients.size, socket);
@@ -232,6 +249,7 @@ export class Server {
 
       // When the socket calls `.close()`, then do the following
       socket.onclose = (ev: CloseEvent) => {
+        console.log("close handler in server");
         // Remove the client
         clients.delete(client.id);
         // Call the disconnect handler if defined
@@ -248,7 +266,6 @@ export class Server {
           disconnectHandler.callback(disconnectEvent);
         }
       };
-
       return response;
     };
   }

--- a/src/websocket_client.ts
+++ b/src/websocket_client.ts
@@ -3,9 +3,9 @@ type Callback = (message: Record<string, unknown>) => void;
 /**
  * A helper class built on top of the native WebSocket, to make it easier to
  * send messages to channels, and listen for messages on channels.
- * 
+ *
  * Specifically built for Drash.
- * 
+ *
  * Only defined an onmessage handler.
  */
 export class WebSocketClient extends WebSocket {

--- a/src/websocket_client.ts
+++ b/src/websocket_client.ts
@@ -1,5 +1,3 @@
-import { deferred } from "../tests/deps.ts";
-
 type Callback = (message: Record<string, unknown>) => void;
 
 /**
@@ -7,14 +5,12 @@ type Callback = (message: Record<string, unknown>) => void;
  * connect and disconnect from servers, and tailored towrads working specifically
  * with a Wocket server
  */
-export class WebSocketClient {
-  #socket: WebSocket;
-
+export class WebSocketClient extends WebSocket {
   #handlers: Map<string, Callback> = new Map();
 
-  constructor(socket: WebSocket) {
-    this.#socket = socket;
-    this.#socket.onmessage = (e) => {
+  constructor(url: string) {
+    super(url);
+    this.onmessage = (e) => {
       const packet = JSON.parse(e.data);
       const { channel, message } = packet;
       const handler = this.#handlers.get(channel);
@@ -22,35 +18,6 @@ export class WebSocketClient {
         handler(message);
       }
     };
-  }
-
-  /**
-   * Entrypoint to create the client.
-   *
-   * The same as:
-   * ```js
-   * const client = new Websocket(...)
-   * const p = deferred()
-   * client.onopen = () => p.resolve()
-   * await p
-   * ```
-   *
-   * @param url - URL for the websocket server, eg "ws://localhost:3000"
-   *
-   * @returns An instance of the WebSocketClient
-   */
-  public static async create(url: string) {
-    const websocket = new WebSocket(url);
-    const p = deferred();
-    websocket.onopen = () => p.resolve();
-    websocket.onerror = (e) => {
-      // deno-lint-ignore ban-ts-comment
-      // @ts-ignore
-      throw new Error(e.message);
-    };
-    await p;
-    websocket.onerror = null;
-    return new WebSocketClient(websocket);
   }
 
   /**
@@ -79,30 +46,14 @@ export class WebSocketClient {
    * @param channelName - The channel name to send to
    * @param message - The message to send to the channel
    */
-  public to(channelName: string, message: Record<string, unknown>) {
+  public to(channelName: string, message: Record<string, unknown>): void {
+    if (this.readyState === WebSocket.CONNECTING) {
+      return this.to(channelName, message);
+    }
     const packet = JSON.stringify({
       channel: channelName,
       message,
     });
-    this.#socket.send(packet);
-  }
-
-  /**
-   * Close the websocket client
-   */
-  public async close() {
-    const p = deferred();
-    this.#socket.onclose = () => p.resolve();
-    this.#socket.close(1000);
-    await p;
-  }
-
-  /**
-   * Register a custom onerror callback
-   *
-   * @param callback - Function to be called if the client receives an error
-   */
-  public onerror(callback: (e: ErrorEvent | Event) => void | Promise<void>) {
-    this.#socket.onerror = callback;
+    this.send(packet);
   }
 }

--- a/src/websocket_client.ts
+++ b/src/websocket_client.ts
@@ -1,9 +1,12 @@
 type Callback = (message: Record<string, unknown>) => void;
 
 /**
- * A helper class to replace the native WebSocket, to make it simpler to
- * connect and disconnect from servers, and tailored towrads working specifically
- * with a Wocket server
+ * A helper class built on top of the native WebSocket, to make it easier to
+ * send messages to channels, and listen for messages on channels.
+ * 
+ * Specifically built for Drash.
+ * 
+ * Only defined an onmessage handler.
  */
 export class WebSocketClient extends WebSocket {
   #handlers: Map<string, Callback> = new Map();

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,3 +1,6 @@
 export { Rhum } from "https://deno.land/x/rhum@v1.1.11/mod.ts";
-export { deferred } from "https://deno.land/std@0.104.0/async/deferred.ts";
-export { assertEquals } from "https://deno.land/std@0.104.0/testing/asserts.ts";
+export { deferred, delay } from "https://deno.land/std@0.104.0/async/mod.ts";
+export {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.104.0/testing/asserts.ts";

--- a/tests/integration/paths_test.ts
+++ b/tests/integration/paths_test.ts
@@ -1,0 +1,47 @@
+import { Server } from "../../mod.ts";
+import { assertEquals, deferred } from "../deps.ts";
+import { WebSocketClient } from "../../src/websocket_client.ts";
+
+Deno.test("Can use paths with the server", async () => {
+  const server = new Server({
+    hostname: "localhost",
+    port: 1447,
+    protocol: "ws",
+    path: "/my-app/users",
+  });
+  server.run();
+
+  // client1 should close normally
+  const client1 = new WebSocketClient(server.address + "/my-app/users");
+  const p1 = deferred<{
+    code: number;
+    reason: string;
+  }>();
+  client1.onclose = (e) => {
+    p1.resolve({
+      code: e.code,
+      reason: e.reason,
+    });
+  };
+  client1.close();
+  const p1Result = await p1;
+
+  // Client2 should be closed by server
+  const client2 = new WebSocketClient(server.address);
+  const p2 = deferred<string>();
+  // deno-lint-ignore ban-ts-comment
+  // @ts-ignore
+  client2.onerror = (e) => p2.resolve(e.message);
+  const p2Result = await p2;
+
+  await server.close();
+
+  assertEquals(p1Result, {
+    code: 0,
+    reason: "",
+  });
+  assertEquals(
+    p2Result,
+    "NetworkError: failed to connect to WebSocket: HTTP error: 406 Not Acceptable",
+  );
+});


### PR DESCRIPTION
restructured the ws client, i quickly realised that it was alot for us to take on, to handle all the events, the closing, the codes etc etc, so what i've gone with instead is:

- class extends native Websocket, called with new instead of .create (idea from @crookse)
- Removed close method, and logic to wait until its open

The client is now purely just a nice wrapper around sending and handling messages

And added path support