### PR TITLE
feat: Support sending strings as messages

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -107,7 +107,7 @@ export class Server {
    */
   public to(
     channelName: string,
-    message: Record<string, unknown>,
+    message: Record<string, unknown> | string,
     onlySendTo?: number,
   ): void {
     // If sending to a specific client, only do that
@@ -274,7 +274,7 @@ export class Server {
   #send(
     clientId: number,
     channelName: string,
-    message: Record<string, unknown>,
+    message: Record<string, unknown> | string,
   ) {
     const client = this.clients.get(clientId);
     client!.socket.send(JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,6 @@ type ReservedChannelProps<ChannelName> = ChannelName extends "disconnect"
  */
 export type OnChannelCallback<CustomProps, ChannelName extends string> = ((
   event: CustomEvent<
-    CustomProps & ReservedChannelProps<ChannelName> & AlwaysProps
+    { packet: CustomProps } & ReservedChannelProps<ChannelName> & AlwaysProps
   >,
 ) => void);

--- a/tests/integration/server_throws_when_client_sends_to_non_existing_channel_test.ts
+++ b/tests/integration/server_throws_when_client_sends_to_non_existing_channel_test.ts
@@ -1,0 +1,30 @@
+import { Server } from "../../mod.ts";
+import { assertEquals, deferred } from "../deps.ts";
+import { WebSocketClient } from "../../src/websocket_client.ts";
+
+Deno.test("Server throws when client sends a message to a channel that doesn't exist", async () => {
+  const server = new Server({
+    hostname: "localhost",
+    port: 1447,
+    protocol: "ws",
+  });
+  server.run();
+  const msgPromise = deferred<MessageEvent>();
+
+  const client = new WebSocketClient(server.address);
+  client.onmessage = (e) => msgPromise.resolve(e);
+  const p = deferred();
+  client.onopen = () => p.resolve();
+  await p;
+  client.to("usersssss", "hello");
+  const msg = await msgPromise;
+  const p2 = deferred();
+  client.onclose = () => p2.resolve();
+  client.close();
+  await p2;
+  await server.close();
+  assertEquals(
+    msg.data,
+    `The channel "usersssss" doesn't exist as the server hasn't created a listener for it`,
+  );
+});

--- a/tests/integration/tests.ts
+++ b/tests/integration/tests.ts
@@ -44,7 +44,7 @@ Deno.test("Full fledged end to end test", async () => {
     id: number; // client socket id
   };
   server.on<UserMessage>("channel", (event) => {
-    const { username, sender, id } = event.detail;
+    const { username, sender, id } = event.detail.packet;
     channelCalled = {
       username,
       sender,

--- a/tests/unit/server_test.ts
+++ b/tests/unit/server_test.ts
@@ -84,7 +84,7 @@ Rhum.testPlan("unit/server_test.ts", () => {
         name: string;
       }>("custom-channel", (e) => {
         e.detail.id;
-        e.detail.name;
+        e.detail.packet.name;
       });
     });
   });


### PR DESCRIPTION
closes #135 

So now:

```ts
client.to("users", "hello")

server.on<string>("users", e => console.log(e.detail.packet)) // "hello"