### PR TITLE
fix: First client id being 0

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -206,7 +206,7 @@ export class Server {
       const { socket, response } = Deno.upgradeWebSocket(r);
 
       // Create the client
-      const client = new Client(clients.size, socket);
+      const client = new Client(clients.size + 1, socket);
       clients.set(clients.size, client);
 
       socket.onopen = () => {


### PR DESCRIPTION
Still works, just felt weird that the first clients id was 0, which can cause some edge cases as its a falsy value (say the user does a conditional on it)